### PR TITLE
Add setUnixTime

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -29,6 +29,7 @@ disablePeriodicTimer	KEYWORD2
 enablePeriodicTimeUpdate    KEYWORD2
 clearInterruptFlags    KEYWORD2
 getUnixTime    KEYWORD2
+setUnixTime    KEYWORD2
 initDevice    KEYWORD2
 
 readFromRegister	KEYWORD2

--- a/src/Melopero_RV3028.cpp
+++ b/src/Melopero_RV3028.cpp
@@ -154,6 +154,11 @@ uint32_t Melopero_RV3028::getUnixTime(){
     return unixTime;
 }
 
+void Melopero_RV3028::setUnixTime(uint32_t secondsSinceEpoch){
+    uint8_t secondsArray[4] = {(uint8_t)secondsSinceEpoch, (uint8_t)(secondsSinceEpoch >> 8), (uint8_t)(secondsSinceEpoch >> 16), (uint8_t)(secondsSinceEpoch >> 24)};
+    writeToRegisters(UNIX_TIME_ADDRESS, secondsArray, 4);
+}
+
 bool Melopero_RV3028::isDateModeForAlarm(){
     return (readFromRegister(CONTROL1_REGISTER_ADDRESS) & DATE_ALARM_MODE_FLAG) > 0;
 }

--- a/src/Melopero_RV3028.h
+++ b/src/Melopero_RV3028.h
@@ -78,6 +78,7 @@ class Melopero_RV3028 {
         uint16_t getYear();
 
         uint32_t getUnixTime();
+        void setUnixTime(uint32_t secondsSinceEpoch);
 
         void set24HourMode();
         void set12HourMode();

--- a/src/Melopero_RV3028.h
+++ b/src/Melopero_RV3028.h
@@ -123,6 +123,7 @@ class Melopero_RV3028 {
         // Sets up the device to read/write from/to the eeprom memory. The automatic refresh function has to be disabled.
         void useEEPROM(bool disableRefresh = true);
         bool isEEPROMBusy();
+        bool waitforEEPROM();
         uint8_t readEEPROMRegister(uint8_t registerAddress);
         void writeEEPROMRegister(uint8_t registerAddress, uint8_t value);
 


### PR DESCRIPTION
The unixtime and the time set via setHour, setMinute,... are not synchronised - they are two different timers. 
I have added the setUnixTime function so that you can also use the unixtime. 